### PR TITLE
Mark cached responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### Added
 <!--- - <description> (#<PR_number, kudos to @<author>) --->
+- Mark cached responses ([#30](https://github.com/AckeeCZ/Reqres/pull/30), kudos to @janmisar)
 - Run SwiftLint on build if installed locally ([#29](https://github.com/AckeeCZ/ACKategories/pull/29), kudos to @olejnjak)
 
 ## 3.1.1

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Register Reqres on application startup and it will monitor and log any requests 
 Reqres.register()
 ```
 
-## Customization
+## Features & customization
 You can do some settings to make it fit your needs.
 
 ### Custom logger
@@ -111,6 +111,28 @@ Reqres uses emoji to make log better to read and to make it at least a little fu
 ```swift
 Reqres.allowUTF8Emoji = false
 ```
+
+### Marking cached responses
+Reqres by default marks responses coming from cache with `[CACHED]`. You can disable it by setting
+```swift
+Reqres.markCachedResponses = false
+```
+
+This feature is based on response `Date` header and start time of the request.
+
+If `Date` from the response header is earlier than start date of the request, it's cached response. `Date` is time
+when response was created on the server, so it's impossible for the request to be older than response if not cached.
+
+`startDate` is `Date` created from `Date()` so it's very precise. On the other hand, date parsed from header is rounded to
+seconds, so if API is really fast (< 1s), it marks even fresh response as cached. For example...
+
+```
+request start time: 9:23:31.100
+response time: 9:23:31.500 (but sent as 9:23:31 without miliseconds)
+```
+
+So response seems to be older than request but in fact is not. That's why we mark response as cached only if response time
+is more than 1 second earlier than start time to avoid this.
 
 ## Forking this repository
 If you use Reqres in your projects drop us as tweet at [@ackeecz][1]. We would love to hear about it!


### PR DESCRIPTION
It could be very useful to see which requests are returned from cache and which are not. There seems to be no way to do it 100% reliable but I think this implementation is good enough for debug purposes.

#### Checklist
<!-- DO NOT REMOVE THIS CHECKLIST OR YOU'LL BURN IN HELL 🔥🧨💣 -->
- [x] Added tests (if applicable)
